### PR TITLE
Update Offline TPG To Match Online

### DIFF
--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
@@ -93,9 +93,8 @@ public:
   // Absolute-value running sum
   void abs_run_sum(const int16_t sample) {
     // R-value should be a float in range [0,1], but we're working with integers
-    // online. So multiply everything by 10 and then de-scale.
-    running_sum_ =   r_value_ * running_sum_ + std::abs(sample) * scale_factor_;
-    running_sum_ = running_sum_ / 10;
+    // online. Divide using online division first, then scale up.
+    running_sum_ = r_value_ * avx2_divide(running_sum_, 10) + avx2_divide(std::abs(sample), 10) * scale_factor_;
   }
 
 

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
@@ -166,11 +166,7 @@ public:
       if (is_over) {
         // we are over threshold, so need to update the hit charge and check for
         // peak time
-
-        int32_t tmp_charge = hit_charge_;
-        tmp_charge += sample;
-        // tmp_charge = std::min(tmp_charge,
-        // (int32_t)std::numeric_limits<int16_t>::max()); // 32767
+        hit_charge_ += sample;
 
         // check if we're at the peak adc
         if (sample > hit_peak_adc_) {
@@ -178,8 +174,7 @@ public:
           hit_peak_time_ = hit_tover_;
         }
 
-        // update charge and time over threshold
-        hit_charge_ = (uint32_t)tmp_charge;
+        // update time over threshold
         ++hit_tover_;
       }
       if (prev_was_over_ && !is_over) {
@@ -229,10 +224,10 @@ private:
   //  int16_t accum75_;
 
   uint16_t prev_was_over_;
-  uint16_t hit_charge_;
   uint16_t hit_tover_;
   uint16_t hit_peak_time_;
   uint16_t hit_peak_adc_;
+  uint32_t hit_charge_;
 };
 
 } // namespace dunetrigger

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
@@ -94,7 +94,13 @@ public:
   void abs_run_sum(const int16_t sample) {
     // R-value should be a float in range [0,1], but we're working with integers
     // online. Divide using online division first, then scale up.
-    running_sum_ = r_value_ * avx2_divide(running_sum_, 10) + avx2_divide(std::abs(sample), 10) * scale_factor_;
+    const int16_t tmp_sum = r_value_ * avx2_divide(running_sum_, 10) + avx2_divide(std::abs(sample), 10) * scale_factor_;
+
+    // Saturated additions. AbsRS should be strictly positive, so a negative tmp_sum indicates overflow.
+    if (tmp_sum < 0)
+      running_sum_ = std::numeric_limits<int16_t>::max();  // Set the sum to the saturation limit.
+    else
+      running_sum_ = tmp_sum;
   }
 
 

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh
@@ -22,7 +22,7 @@ public:
   explicit TPAlgTPCAbsRunningSum(fhicl::ParameterSet const &ps)
       : verbosity_(ps.get<int>("verbosity", 0)),
         accum_limit_(ps.get<int>("accum_limit", 10)),
-        scale_factor_(ps.get<int>( "scale_factor", 2)), // AbsRS-specific parameter ensuring the scale of hit parameters remains in the same ballpark as raw ADCs 
+        scale_factor_(ps.get<int>( "scale_factor", 5)), // AbsRS-specific parameter ensuring the scale of hit parameters remains in the same ballpark as raw ADCs 
         r_value_(ps.get<int>("r_value", 9)), // AbsRS-specific "memory" parameter.
         threshold_tpg_plane0_(ps.get<int16_t>("threshold_tpg_plane0")),
         threshold_tpg_plane1_(ps.get<int16_t>("threshold_tpg_plane1")),
@@ -94,7 +94,7 @@ public:
   void abs_run_sum(const int16_t sample) {
     // R-value should be a float in range [0,1], but we're working with integers
     // online. So multiply everything by 10 and then de-scale.
-    running_sum_ =   r_value_ * running_sum_ + std::abs((sample * 10) / scale_factor_);
+    running_sum_ =   r_value_ * running_sum_ + std::abs(sample) * scale_factor_;
     running_sum_ = running_sum_ / 10;
   }
 

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
@@ -92,7 +92,16 @@ public:
   void run_sum(const int16_t sample) {
     // R-value should be a float in range [0,1], but we're working with integers
     // online. Divide using online division first, then scale up.
-    running_sum_ = r_value_ * avx2_divide(running_sum_, 10) + avx2_divide(sample, 10) * scale_factor_;
+    const int16_t tmp_sum = r_value_ * avx2_divide(running_sum_, 10) + avx2_divide(sample, 10) * scale_factor_;
+
+    // Saturated additions. Running sum is not strictly positive. Need to check the direction the sum should
+    // go, then apply the correct saturation limit.
+    if (sample > 0 && running_sum_ > 0 && tmp_sum < 0)      // Both terms positive, so overflow would be negative.
+      running_sum_ = std::numeric_limits<int16_t>::max();   // Set the RS to saturated max.
+    else if (sample < 0 && running_sum < 0 && tmp_sum > 0)  // Both terms negative, so overflow would be positive.
+      running_sum_ = std::numeric_limits<int16_t>::min();   // Set the RS to saturated min.
+    else
+      running_sum_ = tmp_sum;
   }
 
 

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
@@ -91,9 +91,8 @@ public:
   // Standard running sum
   void run_sum(const int16_t sample) {
     // R-value should be a float in range [0,1], but we're working with integers
-    // online. So multiply everything by 10 and then de-scale.
-    running_sum_ =   r_value_ * running_sum_ + sample * scale_factor_;
-    running_sum_ = running_sum_ / 10;
+    // online. Divide using online division first, then scale up.
+    running_sum_ = r_value_ * avx2_divide(running_sum_, 10) + avx2_divide(sample, 10) * scale_factor_;
   }
 
 

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
@@ -136,11 +136,7 @@ public:
       if (is_over) {
         // we are over threshold, so need to update the hit charge and check for
         // peak time
-
-        int32_t tmp_charge = hit_charge_;
-        tmp_charge += sample;
-        // tmp_charge = std::min(tmp_charge,
-        // (int32_t)std::numeric_limits<int16_t>::max()); // 32767
+        hit_charge_ += sample;
 
         // check if we're at the peak adc
         if (sample > hit_peak_adc_) {
@@ -148,8 +144,7 @@ public:
           hit_peak_time_ = hit_tover_;
         }
 
-        // update charge and time over threshold
-        hit_charge_ = (uint32_t)tmp_charge;
+        // update time over threshold
         ++hit_tover_;
       }
       if (prev_was_over_ && !is_over) {
@@ -197,10 +192,10 @@ private:
   //  int16_t accum75_;
 
   uint16_t prev_was_over_;
-  uint16_t hit_charge_;
   uint16_t hit_tover_;
   uint16_t hit_peak_time_;
   uint16_t hit_peak_adc_;
+  uint32_t hit_charge_;
 };
 
 } // namespace dunetrigger

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh
@@ -22,7 +22,7 @@ public:
   explicit TPAlgTPCRunningSum(fhicl::ParameterSet const &ps)
       : verbosity_(ps.get<int>("verbosity", 0)),
         accum_limit_(ps.get<int>("accum_limit", 10)),
-        scale_factor_(ps.get<int>( "scale_factor", 2)), //RS-specific parameter ensuring the scale of hit parameters remains in the same ballpark as raw ADCs 
+        scale_factor_(ps.get<int>( "scale_factor", 5)), //RS-specific parameter ensuring the scale of hit parameters remains in the same ballpark as raw ADCs 
         r_value_(ps.get<int>("r_value", 9)), // RS-specific "memory" parameter.
         threshold_tpg_plane0_(ps.get<int16_t>("threshold_tpg_plane0")),
         threshold_tpg_plane1_(ps.get<int16_t>("threshold_tpg_plane1")),
@@ -92,7 +92,7 @@ public:
   void run_sum(const int16_t sample) {
     // R-value should be a float in range [0,1], but we're working with integers
     // online. So multiply everything by 10 and then de-scale.
-    running_sum_ =   r_value_ * running_sum_ + (sample * 10) / scale_factor_;
+    running_sum_ =   r_value_ * running_sum_ + sample * scale_factor_;
     running_sum_ = running_sum_ / 10;
   }
 

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCSimpleThreshold.hh
@@ -123,11 +123,7 @@ namespace dunetrigger {
             if(is_over)
             {
                 //we are over threshold, so need to update the hit charge and check for peak time
-
-                //first, need to saturate hit_charge at int16
-                int32_t tmp_charge = hit_charge_;
-                tmp_charge += sample;
-                // tmp_charge = std::min(tmp_charge, (int32_t)std::numeric_limits<int16_t>::max()); // 32767
+                hit_charge_ += sample;
 
                 //check if we're at the peak adc
                 if(sample > hit_peak_adc_){
@@ -135,8 +131,7 @@ namespace dunetrigger {
                     hit_peak_time_ = hit_tover_;
                 }
 
-                //update charge and time over threshold
-                hit_charge_ = (uint16_t)tmp_charge;
+                //update time over threshold
                 ++hit_tover_;
             }
             if(prev_was_over_ && !is_over)
@@ -179,10 +174,10 @@ namespace dunetrigger {
    // int16_t accum75_;
 
     uint16_t prev_was_over_;
-    uint16_t hit_charge_;
     uint16_t hit_tover_;
     uint16_t hit_peak_time_;
     uint16_t hit_peak_adc_;
+    uint32_t hit_charge_;
 
   };
   

--- a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCTool.hh
+++ b/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCTool.hh
@@ -3,6 +3,7 @@
 
 #include "detdataformats/trigger/TriggerPrimitive.hpp"
 
+#include <cstdint>
 #include <vector>
 
 namespace dunetrigger {
@@ -21,6 +22,15 @@ namespace dunetrigger {
 				  dunedaq::trgdataformats::detid_t const detid,
 				  dunedaq::trgdataformats::timestamp_t const start_time,
 				  std::vector<dunedaq::trgdataformats::TriggerPrimitive> & tps_out) = 0;
+
+    inline int16_t avx2_divide(const int16_t& a, const int16_t& b) {
+      int16_t vb = (1 << 15) / b;         //  1 / b * 2^15
+      int32_t mulhrs = a * vb;            //  a / b * 2^15
+      mulhrs = (mulhrs >> 14) + 1;        // (a / b * 2^15) * 2^-14 + 1 ~ a / b * 2 + 1
+      mulhrs = mulhrs >> 1;               //~ a / b. The +1 causes unorthodox rounding.
+      return (int16_t)(mulhrs);
+    }
+
   };
 }
 


### PR DESCRIPTION
Simulated TPG is not consistent with the online TPG implementation. Using the simulated (Sim.) and online implementation (TPG), I processed a waveform from data at the 14 bit signal and processed the same waveform after dividing by 4 to simulate a 12 bit signal.

![sim_26794 0000-2948](https://github.com/user-attachments/assets/705eaabf-8211-42c1-bc0e-637aba10659c)
![sim-12_26794 0000-2948](https://github.com/user-attachments/assets/9c73028f-63dd-4241-a8b5-46b1132b627f)
![sim-diff-12_26794 0000-2948](https://github.com/user-attachments/assets/d98b17dc-3282-4fc4-b03e-aadaf8e1650e)

Online makes use of both saturated addition and alternative definitions of running sum and absolute value running sum to avoid approaching saturation. Online also makes use of `uint32_t` for the TP's ADC integral. The changes in this PR are required for consistency with online TPG.

# ADC Integral Difference
Online implementation makes use of the full range `uint32_t` for a TP's `adc_integral` while simulation is limiting to `uint16_t`. This would most affect the running sum values as `adc_integral` would frequently need more than 16 b.
https://github.com/DUNE/dunetrigger/blob/910aa577459ab140b9eda3dcee5845c2ec5a508a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh#L200
# Running Sum Differences
Both running sum algorithms do not accurately represent the online implementation in multiple fashions.
https://github.com/DUNE/dunetrigger/blob/910aa577459ab140b9eda3dcee5845c2ec5a508a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCAbsRunningSum.hh#L94-L99
https://github.com/DUNE/dunetrigger/blob/910aa577459ab140b9eda3dcee5845c2ec5a508a/dunetrigger/TriggerSim/TPAlgTools/TPAlgTPCRunningSum.hh#L92-L97
## Sample Scale Factor
The representation of `scale_factor_` is inconsistent with online which uses it as a multiplication factor and not division. This removes the need for a multiplication by 10 on the signal sample and avoids a potential saturation.

**Note:** this may be changed in the online case to do **only** the `scale_factor_` division but to not also include the multiplication by 10. Changing this online would preserve more of the original signal, e.g., `(sample / 10) * 5` loses the 1s digit of the original signal while `sample / 2` has some preservation.
## AVX2 Division
For a more accurate representation, one should use the following function in places that require a division:
https://github.com/DUNE-DAQ/tpglibs/blob/62a174fbae8adbce705436065135902ab8073a8c/include/tpglibs/NaiveUtils.hpp#L26-L32
The online implementation for division is an approximation since an exact solution is not explicitly available AVX2 or requires many more instructions to achieve.
## Order Of Operations
Online order of operations divides first to avoid saturating, but this results in precision loss from the incoming sample.TPs and online TPG has the ADC integral at 32 bits, not 16.TPs and online TPG has the ADC integral at 32 bits, not 16.
## Saturated Addition
AVX2 implementations feature a saturated addition function, but C++17 does not have this feature. I've added checks to handle potential overflows with saturation.