### PR TITLE
fix: trigerAnaTree missing from production macro; refactor producer lock to prolog fhicl files

### DIFF
--- a/dunetrigger/TriggerAna/fcl/production/triggerana_tree_1x2x6_tpg_absrs_st.fcl
+++ b/dunetrigger/TriggerAna/fcl/production/triggerana_tree_1x2x6_tpg_absrs_st.fcl
@@ -13,17 +13,4 @@ services: {
 source:	@local::source_triggerana_tree
 outputs: @local::outputs_triggerana_tree
 
-producers_triggersim_simpleThr_absRS: {
-	tpmakerTPCsimpleThr: @local::tpmakerTPC_ADCSimpleThreshold
-	tpmakerTPCabsRS: @local::tpmakerTPC_ABSRunningSum
-}
-
-physics_triggersim_simpleThr_absRS: {
-	producers: @local::producers_triggersim_simpleThr_absRS
-	stream1: [ out1 ]
-	makers: [ tpmakerTPCsimpleThr, tpmakerTPCabsRS ]
-	trigger_paths: [ makers ]
-	end_paths: [ stream1 ]
-}
-
 physics: @local::physics_triggersim_simpleThr_absRS

--- a/dunetrigger/TriggerAna/fcl/triggerana_tree.fcl
+++ b/dunetrigger/TriggerAna/fcl/triggerana_tree.fcl
@@ -50,4 +50,8 @@ physics_triggerana_tree_simpleThr_simpleWin_simpleWin: {
   end_paths:      [ stream1, ana ]
 }
 
+physics_triggersim_simpleThr_absRS: @local::physics_triggerana_tree_simpleThr_simpleWin_simpleWin
+physics_triggersim_simpleThr_absRS.producers: @local::producers_triggersim_simpleThr_absRS
+physics_triggersim_simpleThr_absRS.makers: [ tpmakerTPCsimpleThr, tpmakerTPCabsRS ]
+
 END_PROLOG

--- a/dunetrigger/TriggerSim/fcl/triggersim.fcl
+++ b/dunetrigger/TriggerSim/fcl/triggersim.fcl
@@ -39,6 +39,12 @@ producers_triggersim_simpleThr_simpleWin_simpleWin: {
     tcmakerTPC: @local::tcmakerTPC_ADCSimpleWindow
 }
 
+# Run both AbsRS and SimpleThreshold TPG
+producers_triggersim_simpleThr_absRS: {
+	tpmakerTPCsimpleThr: @local::tpmakerTPC_ADCSimpleThreshold
+	tpmakerTPCabsRS: @local::tpmakerTPC_ABSRunningSum
+}
+
 # this does not have analyzers! Add them
 physics_triggersim_simpleThr_simpleWin_simpleWin: {
     producers: @local::producers_triggersim_simpleThr_simpleWin_simpleWin


### PR DESCRIPTION
Previously production fhicl files did not include calls to TriggerAnaTree:(

