### PR TITLE
Improvements to AnaTree and FHiCL files for production purposes. 

### DIFF
--- a/dunetrigger/TriggerAna/fcl/production/triggerana_tree_1x2x2_tpg_absrs_st.fcl
+++ b/dunetrigger/TriggerAna/fcl/production/triggerana_tree_1x2x2_tpg_absrs_st.fcl
@@ -2,6 +2,7 @@
 
 #include "triggerana_tree_1x2x6_tpg_absrs_st.fcl"
 
+process_name: TriggerAnaTree1x2x2
 services: {
 	@table::services_triggersim
 	@table::dunefd_1x2x2_reco_services

--- a/dunetrigger/TriggerAna/fcl/production/triggerana_tree_1x2x6_tpg_absrs_st.fcl
+++ b/dunetrigger/TriggerAna/fcl/production/triggerana_tree_1x2x6_tpg_absrs_st.fcl
@@ -13,4 +13,4 @@ services: {
 source:	@local::source_triggerana_tree
 outputs: @local::outputs_triggerana_tree
 
-physics: @local::physics_triggersim_simpleThr_absRS
+physics: @local::physics_triggerana_simpleThr_absRS

--- a/dunetrigger/TriggerAna/fcl/triggerana_tree.fcl
+++ b/dunetrigger/TriggerAna/fcl/triggerana_tree.fcl
@@ -50,8 +50,8 @@ physics_triggerana_tree_simpleThr_simpleWin_simpleWin: {
   end_paths:      [ stream1, ana ]
 }
 
-physics_triggersim_simpleThr_absRS: @local::physics_triggerana_tree_simpleThr_simpleWin_simpleWin
-physics_triggersim_simpleThr_absRS.producers: @local::producers_triggersim_simpleThr_absRS
-physics_triggersim_simpleThr_absRS.makers: [ tpmakerTPCsimpleThr, tpmakerTPCabsRS ]
+physics_triggerana_simpleThr_absRS: @local::physics_triggerana_tree_simpleThr_simpleWin_simpleWin
+physics_triggerana_simpleThr_absRS.producers: @local::producers_triggersim_simpleThr_absRS
+physics_triggerana_simpleThr_absRS.makers: [ tpmakerTPCsimpleThr, tpmakerTPCabsRS ]
 
 END_PROLOG


### PR DESCRIPTION
- Per @alessandrothea 's suggestion, we move to the better optimized TP v2 storage layout in the triggerAnaTree. Currently we cast a V1 TP to a bit-field expanded version of TP v2, but this could change in the future should we start to produce TPv2 objects natively -- reduces AnaTree output size by 10%...
- Small Fhicl prolog block naming fix to avoid AnaTree from producing root trees with incorrect names (1x2x6 vs 1x2x2). 